### PR TITLE
W-17328863 - Support for other SF subdomains

### DIFF
--- a/src/main/java/com/mule/mulechain/internal/MuleChainEinstein1ConnectionProvider.java
+++ b/src/main/java/com/mule/mulechain/internal/MuleChainEinstein1ConnectionProvider.java
@@ -61,7 +61,7 @@ public class MuleChainEinstein1ConnectionProvider implements PoolingConnectionPr
   @Override
   public ConnectionValidationResult validate(MuleChainEinstein1Connection connection) {
     try {
-      String urlStr = "https://" + connection.getSalesforceOrg() + ".my.salesforce.com/services/oauth2/token";
+      String urlStr = "https://" + connection.getSalesforceOrg() + "/services/oauth2/token";
       String urlParameters = "grant_type=client_credentials&client_id=" + connection.getClientId() + "&client_secret=" + connection.getClientSecret();
       byte[] postData = urlParameters.getBytes(StandardCharsets.UTF_8);
 

--- a/src/main/java/com/mule/mulechain/internal/MuleChainEinstein1ConnectionProvider.java
+++ b/src/main/java/com/mule/mulechain/internal/MuleChainEinstein1ConnectionProvider.java
@@ -28,7 +28,7 @@ public class MuleChainEinstein1ConnectionProvider implements PoolingConnectionPr
   @Override
   public MuleChainEinstein1Connection connect() throws ConnectionException {
     try {
-      String urlStr = "https://" + salesforceOrg + ".my.salesforce.com/services/oauth2/token";
+      String urlStr = "https://" + salesforceOrg + "/services/oauth2/token";
       String urlParameters = "grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret;
       byte[] postData = urlParameters.getBytes(StandardCharsets.UTF_8);
 

--- a/src/main/java/com/mule/mulechain/internal/helpers/MuleChainEinstein1PayloadHelper.java
+++ b/src/main/java/com/mule/mulechain/internal/helpers/MuleChainEinstein1PayloadHelper.java
@@ -63,7 +63,7 @@ public class MuleChainEinstein1PayloadHelper {
 
 
     public static String getAccessToken(String org, String consumerKey, String consumerSecret) {
-    String urlString = "https://" + org + ".my.salesforce.com/services/oauth2/token";
+    String urlString = "https://" + org + "/services/oauth2/token";
     String params = "grant_type=client_credentials&client_id=" + consumerKey + "&client_secret=" + consumerSecret;
 
     try {


### PR DESCRIPTION
There are certain internal services relying on different subdomains than my.salesforce.com. This include, but is not limited to, OrgFarm, TOFU and Trailhead.

Example:

<img width="872" alt="image" src="https://github.com/user-attachments/assets/4c033828-e7cf-4645-a196-8e80fce188f1">

The idea behind this simple change is to allow users to pass the full host as the Salesforce org parameter in the connector provider. This way, the provider validates the connection to other domains, as follows:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/98cc8887-7bd3-44d4-a5e8-fa4dc7c9c953">
